### PR TITLE
feat: remove anyhow errors from Rust lib

### DIFF
--- a/flipt-client-rust/Cargo.lock
+++ b/flipt-client-rust/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +140,6 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 name = "flipt"
 version = "0.0.1"
 dependencies = [
- "anyhow",
  "chrono",
  "reqwest",
  "serde",

--- a/flipt-client-rust/Cargo.toml
+++ b/flipt-client-rust/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 keywords = ["flipt"]
 
 [dependencies]
-anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "clock"] }
 reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/flipt-client-rust/examples/evaluations.rs
+++ b/flipt-client-rust/examples/evaluations.rs
@@ -2,12 +2,11 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
 use flipt::evaluation::models::{BatchEvaluationRequest, EvaluationRequest};
 use flipt::FliptClient;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = FliptClient::default();
 
     let mut context: HashMap<String, String> = HashMap::new();

--- a/flipt-client-rust/src/error.rs
+++ b/flipt-client-rust/src/error.rs
@@ -12,6 +12,26 @@ pub struct UpstreamError {
     pub details: Option<Vec<serde_json::Value>>,
 }
 
+impl Default for UpstreamError {
+    fn default() -> Self {
+        Self {
+            code: 0,
+            message: "internal error".into(),
+            details: Some(Vec::new()),
+        }
+    }
+}
+
+impl UpstreamError {
+    pub fn default_with_message(message: String) -> Self {
+        Self {
+            code: 0,
+            message,
+            details: Some(Vec::new()),
+        }
+    }
+}
+
 impl Error for UpstreamError {}
 
 impl Display for UpstreamError {
@@ -24,5 +44,24 @@ impl Display for UpstreamError {
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClientError {
+    pub message: String,
+}
+
+impl ClientError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl Error for ClientError {}
+
+impl Display for ClientError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "Client error: {}", self.message)
     }
 }

--- a/flipt-client-rust/src/evaluation/mod.rs
+++ b/flipt-client-rust/src/evaluation/mod.rs
@@ -1,6 +1,6 @@
 pub mod models;
 
-use crate::util::deserialize;
+use crate::{error::UpstreamError, util::deserialize};
 use models::{
     BatchEvaluationRequest, BatchEvaluationResponse, BooleanEvaluationResponse, EvaluationRequest,
     VariantEvaluationResponse,
@@ -21,10 +21,15 @@ impl Evaluation {
     pub async fn boolean(
         &self,
         request: &EvaluationRequest,
-    ) -> anyhow::Result<BooleanEvaluationResponse> {
+    ) -> Result<BooleanEvaluationResponse, UpstreamError> {
         let endpoint = format!("{}evaluate/v1/boolean", self.url.as_str());
 
-        let response = self.client.post(endpoint).json(request).send().await?;
+        let response = match self.client.post(endpoint).json(request).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(UpstreamError::default_with_message(e.to_string()));
+            }
+        };
 
         deserialize(response).await
     }
@@ -32,10 +37,15 @@ impl Evaluation {
     pub async fn variant(
         &self,
         request: &EvaluationRequest,
-    ) -> anyhow::Result<VariantEvaluationResponse> {
+    ) -> Result<VariantEvaluationResponse, UpstreamError> {
         let endpoint = format!("{}evaluate/v1/variant", self.url.as_str());
 
-        let response = self.client.post(endpoint).json(request).send().await?;
+        let response = match self.client.post(endpoint).json(request).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(UpstreamError::default_with_message(e.to_string()));
+            }
+        };
 
         deserialize(response).await
     }
@@ -43,10 +53,15 @@ impl Evaluation {
     pub async fn batch(
         &self,
         batch: &BatchEvaluationRequest,
-    ) -> anyhow::Result<BatchEvaluationResponse> {
+    ) -> Result<BatchEvaluationResponse, UpstreamError> {
         let endpoint = format!("{}evaluate/v1/batch", self.url.as_str());
 
-        let response = self.client.post(endpoint).json(batch).send().await?;
+        let response = match self.client.post(endpoint).json(batch).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(UpstreamError::default_with_message(e.to_string()));
+            }
+        };
 
         deserialize(response).await
     }

--- a/flipt-client-rust/src/lib.rs
+++ b/flipt-client-rust/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod evaluation;
 pub mod util;
 
+use error::ClientError;
 use evaluation::Evaluation;
 use reqwest::header::HeaderMap;
 use std::time::Duration;
@@ -12,7 +13,7 @@ pub struct FliptClient {
 }
 
 impl FliptClient {
-    pub fn new(url: Url, token: String, timeout: u64) -> anyhow::Result<Self> {
+    pub fn new(url: Url, token: String, timeout: u64) -> Result<Self, ClientError> {
         let mut header_map = HeaderMap::new();
 
         if !token.is_empty() {
@@ -22,10 +23,16 @@ impl FliptClient {
             );
         }
 
-        let client = reqwest::Client::builder()
+        let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(timeout))
             .default_headers(header_map)
-            .build()?;
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => {
+                return Err(ClientError::new(e.to_string()));
+            }
+        };
 
         Ok(Self {
             evaluation: Evaluation::new(client, url),

--- a/flipt-client-rust/src/util/mod.rs
+++ b/flipt-client-rust/src/util/mod.rs
@@ -2,10 +2,20 @@ use crate::error::UpstreamError;
 
 pub async fn deserialize<T: serde::de::DeserializeOwned>(
     resp: reqwest::Response,
-) -> anyhow::Result<T> {
+) -> Result<T, UpstreamError> {
     if resp.status().is_success() {
-        return Ok(resp.json::<T>().await?);
+        match resp.json::<T>().await {
+            Ok(t) => {
+                return Ok(t);
+            }
+            Err(err) => {
+                return Err(UpstreamError::default_with_message(err.to_string()));
+            }
+        }
     }
-    let parsed_err = resp.json::<UpstreamError>().await?;
-    Err(anyhow::Error::new(parsed_err))
+
+    match resp.json::<UpstreamError>().await {
+        Ok(ue) => Err(ue),
+        Err(err) => Err(UpstreamError::default_with_message(err.to_string())),
+    }
 }


### PR DESCRIPTION
Remove `anyhow` lib from Rust client to slim down dependency tree and return a custom error to the client that makes sense from the lib.

Completes FLI-720