### PR TITLE
chore: fix php workflow to copy and push source to the other repo

### DIFF
--- a/flipt-java/build.gradle
+++ b/flipt-java/build.gradle
@@ -63,6 +63,27 @@ publishing {
             artifactId = 'flipt-java'
             from components.java
         }
+
+        pom {
+            name = 'Flipt Java SDK'
+            description = 'Flipt Java SDK'
+            url = 'https://github.com/flipt-io/flipt-server-sdks/tree/main/flipt-java'
+
+            licenses {
+                license {
+                    name = 'MIT'
+                    url = 'https://opensource.org/license/mit/'
+                }
+            }
+
+            developers {
+                developer {
+                    id = 'flipt-io'
+                    name = 'Flipt'
+                    email = 'devs@flipt.io'
+                }
+            }
+        }
     }
     repositories {
         maven {

--- a/flipt-java/build.gradle
+++ b/flipt-java/build.gradle
@@ -62,25 +62,25 @@ publishing {
         maven(MavenPublication) {
             artifactId = 'flipt-java'
             from components.java
-        }
 
-        pom {
-            name = 'Flipt Java SDK'
-            description = 'Flipt Java SDK'
-            url = 'https://github.com/flipt-io/flipt-server-sdks/tree/main/flipt-java'
+            pom {
+                name = 'Flipt Java SDK'
+                description = 'Flipt Java SDK'
+                url = 'https://github.com/flipt-io/flipt-server-sdks/tree/main/flipt-java'
 
-            licenses {
-                license {
-                    name = 'MIT'
-                    url = 'https://opensource.org/license/mit/'
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://opensource.org/license/mit/'
+                    }
                 }
-            }
 
-            developers {
-                developer {
-                    id = 'flipt-io'
-                    name = 'Flipt'
-                    email = 'devs@flipt.io'
+                developers {
+                    developer {
+                        id = 'flipt-io'
+                        name = 'Flipt'
+                        email = 'devs@flipt.io'
+                    }
                 }
             }
         }

--- a/flipt-php/README.md
+++ b/flipt-php/README.md
@@ -5,6 +5,9 @@
 
 This directory contains the PHP source code for the Flipt [server-side](https://www.flipt.io/docs/integration/server/rest) client.
 
+> [!NOTE]
+> If you are on the <https://github.com/flipt-io/flipt-php> repository, this is a mirror of the source code. Please file issues and pull requests against the [flipt-io/flipt-server-sdks](https://github.com/flipt-io/flipt-server-sdks) repository.
+
 ## Status
 
 This SDK status is `beta`, and there may be breaking changes between versions without a major version update. Therefore, we recommend pinning your installation of this package wherever necessary.


### PR DESCRIPTION
This is a update the publish step for PHP to instead of just creating a tag to:
- create a clone of the repo at the tag
- create a [subtree](https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt#L101) of the `flipt-php` folder as a new branch
- push just that branch (so only containing the `flipt-php` folder) up to the already existing https://github.com/flipt-io/flipt-php repo (overwriting main)
- create a new tag for composer

This effectively lets us have a mirror on the `flipt-php` repo of the code in the `flipt-php` folder here. 