### PR TITLE
feat(datadog): Add support for getting RUM metrics for the TypeScript client

### DIFF
--- a/flipt-node/README.md
+++ b/flipt-node/README.md
@@ -22,6 +22,12 @@ In the [example](./example) directory, there is an example TypeScript program wh
 
 There is support for [Datadog RUM](https://docs.datadoghq.com/real_user_monitoring/) through this client. This allows you to track the values of feature flag evaluation and how it relates to active browser sessions.
 
+You can first install the datadog RUM client like so:
+
+```
+npm install --save @datadog/browser-rum
+```
+
 To start tracking feature flags on Datadog:
 
 ```typescript

--- a/flipt-node/README.md
+++ b/flipt-node/README.md
@@ -26,7 +26,7 @@ To start tracking feature flags on Datadog:
 
 ```typescript
 import { datadogRum } from '@datadog/browser-rum';
-import { FliptMetrics } from '@flipt-io/flipt';
+import { FliptClient, FliptMetrics } from '@flipt-io/flipt';
 
 datadogRum.init({
   applicationId: '<APPLICATION_ID>',

--- a/flipt-node/README.md
+++ b/flipt-node/README.md
@@ -17,3 +17,42 @@ npm i @flipt-io/flipt@{version}
 ## Usage
 
 In the [example](./example) directory, there is an example TypeScript program which imports in the flipt client, and uses it appropriately, please refer to that for how to use the client.
+
+### Metrics
+
+There is support for [Datadog RUM](https://docs.datadoghq.com/real_user_monitoring/) through this client. This allows you to track the values of feature flag evaluation and how it relates to active browser sessions.
+
+To start tracking feature flags on Datadog:
+
+```typescript
+import { datadogRum } from '@datadog/browser-rum';
+import { FliptMetrics } from '@flipt-io/flipt';
+
+datadogRum.init({
+  applicationId: '<APPLICATION_ID>',
+  clientToken: '<CLIENT_TOKEN>',
+  site: 'datadoghq.com',
+  service:'<SERVICE_NAME>',
+  env:'<ENV_NAME>',
+  enableExperimentalFeatures: ["feature_flags"],
+  sessionSampleRate:100,
+  sessionReplaySampleRate: 20,
+  trackUserInteractions: true,
+  trackResources: true,
+  trackLongTasks: true,
+  defaultPrivacyLevel:'mask-user-input'
+});
+  
+datadogRum.startSessionReplayRecording();
+
+const metricsClient = new FliptMetrics(new FliptClient({
+  url: "http://localhost:8080",
+}).evaluation, datadogRum);
+
+const response = await metricsClient.variant({
+  namespaceKey: "default",
+  flagKey: "hello-this",
+  entityId: uuidv4(),
+  context: {},
+});
+```

--- a/flipt-node/src/index.ts
+++ b/flipt-node/src/index.ts
@@ -1,4 +1,9 @@
 import { Evaluation } from "./evaluation";
+import {
+  BooleanEvaluationResponse,
+  EvaluationRequest,
+  VariantEvaluationResponse
+} from "./evaluation/models";
 
 interface FliptClientOptions {
   url?: string;
@@ -64,5 +69,39 @@ export class FliptClient {
       clientOptions.timeout,
       clientOptions.authenticationStrategy
     );
+  }
+}
+
+export class FliptMetrics {
+  evaluationClient: Evaluation;
+  datadogRum: any;
+
+  constructor(evaluationClient: Evaluation, datadogRum: any) {
+    this.evaluationClient = evaluationClient;
+    this.datadogRum = datadogRum;
+  }
+
+  public async boolean(
+    request: EvaluationRequest
+  ): Promise<BooleanEvaluationResponse> {
+    const response = await this.evaluationClient.boolean(request);
+
+    this.datadogRum.addFeatureFlagEvaluation(
+      `${request.namespaceKey}/${request.flagKey}`,
+      response.enabled
+    );
+    return response;
+  }
+
+  public async variant(
+    request: EvaluationRequest
+  ): Promise<VariantEvaluationResponse> {
+    const response = await this.evaluationClient.variant(request);
+
+    this.datadogRum.addFeatureFlagEvaluation(
+      `${request.namespaceKey}/${request.flagKey}`,
+      response.variantKey
+    );
+    return response;
   }
 }


### PR DESCRIPTION
Our legacy TypeScript client had the functionality of allowing users to configure the exported client with an instance of datadog RUM. This client lacked that functionality, so this PR is adding that functionality into the new server SDK for node.