### PR TITLE
feat(rust): Add traits for generalizing the token strategy

### DIFF
--- a/flipt-rust/src/api/mod.rs
+++ b/flipt-rust/src/api/mod.rs
@@ -1,6 +1,6 @@
 use crate::error::ClientError;
 use crate::evaluation::Evaluation;
-use crate::{AuthenticationStrategy, ClientTokenAuthentication, Config};
+use crate::{AuthenticationStrategy, Config, NoneAuthentication};
 use reqwest::header::HeaderMap;
 use std::time::Duration;
 
@@ -37,6 +37,6 @@ impl FliptClient {
 
 impl Default for FliptClient {
     fn default() -> Self {
-        Self::new::<ClientTokenAuthentication>(Config::default()).unwrap()
+        Self::new::<NoneAuthentication>(Config::default()).unwrap()
     }
 }

--- a/flipt-rust/src/api/mod.rs
+++ b/flipt-rust/src/api/mod.rs
@@ -1,7 +1,6 @@
 use crate::error::ClientError;
 use crate::evaluation::Evaluation;
 use crate::{AuthenticationStrategy, Config, NoneAuthentication};
-use reqwest::header::HeaderMap;
 use std::time::Duration;
 
 pub struct FliptClient {
@@ -13,10 +12,7 @@ impl FliptClient {
     where
         T: AuthenticationStrategy,
     {
-        let header_map = match config.auth_strategy {
-            Some(a) => a.authenticate(),
-            None => HeaderMap::new(),
-        };
+        let header_map = config.auth_strategy.authenticate();
 
         let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout))

--- a/flipt-rust/src/lib.rs
+++ b/flipt-rust/src/lib.rs
@@ -3,32 +3,92 @@ pub mod error;
 pub mod evaluation;
 pub mod util;
 
+use reqwest::header::HeaderMap;
 use url::Url;
 
 #[derive(Debug, Clone)]
-pub struct Config {
+pub struct Config<T>
+where
+    T: AuthenticationStrategy,
+{
     endpoint: Url,
-    auth_scheme: AuthScheme,
+    auth_strategy: Option<T>,
     timeout: u64,
 }
 
-impl Default for Config {
+impl<T> Default for Config<T>
+where
+    T: AuthenticationStrategy,
+{
     fn default() -> Self {
         Self {
             endpoint: Url::parse("http://localhost:8080").unwrap(),
-            auth_scheme: AuthScheme::None,
+            auth_strategy: None,
             timeout: 60,
         }
     }
 }
 
-impl Config {
-    pub fn new(endpoint: Url, auth_scheme: AuthScheme, timeout: u64) -> Self {
+impl<T> Config<T>
+where
+    T: AuthenticationStrategy,
+{
+    pub fn new(endpoint: Url, auth_strategy: T, timeout: u64) -> Self {
         Self {
             endpoint,
-            auth_scheme,
+            auth_strategy: Some(auth_strategy),
             timeout,
         }
+    }
+}
+
+pub trait AuthenticationStrategy {
+    fn authenticate(self) -> HeaderMap;
+}
+
+pub struct JWTAuthentication {
+    jwt_token: String,
+}
+
+impl JWTAuthentication {
+    pub fn new(jwt_token: String) -> Self {
+        Self { jwt_token }
+    }
+}
+
+impl AuthenticationStrategy for JWTAuthentication {
+    fn authenticate(self) -> HeaderMap {
+        let mut header_map = HeaderMap::new();
+
+        header_map.insert(
+            "Authorization",
+            format!("JWT {}", self.jwt_token).parse().unwrap(),
+        );
+
+        header_map
+    }
+}
+
+pub struct ClientTokenAuthentication {
+    client_token: String,
+}
+
+impl ClientTokenAuthentication {
+    pub fn new(client_token: String) -> Self {
+        Self { client_token }
+    }
+}
+
+impl AuthenticationStrategy for ClientTokenAuthentication {
+    fn authenticate(self) -> HeaderMap {
+        let mut header_map = HeaderMap::new();
+
+        header_map.insert(
+            "Authorization",
+            format!("Bearer {}", self.client_token).parse().unwrap(),
+        );
+
+        header_map
     }
 }
 

--- a/flipt-rust/src/lib.rs
+++ b/flipt-rust/src/lib.rs
@@ -12,18 +12,15 @@ where
     T: AuthenticationStrategy,
 {
     endpoint: Url,
-    auth_strategy: Option<T>,
+    auth_strategy: T,
     timeout: u64,
 }
 
-impl<T> Default for Config<T>
-where
-    T: AuthenticationStrategy,
-{
+impl Default for Config<NoneAuthentication> {
     fn default() -> Self {
         Self {
             endpoint: Url::parse("http://localhost:8080").unwrap(),
-            auth_strategy: None,
+            auth_strategy: NoneAuthentication::default(),
             timeout: 60,
         }
     }
@@ -36,7 +33,7 @@ where
     pub fn new(endpoint: Url, auth_strategy: T, timeout: u64) -> Self {
         Self {
             endpoint,
-            auth_strategy: Some(auth_strategy),
+            auth_strategy,
             timeout,
         }
     }
@@ -47,6 +44,18 @@ pub trait AuthenticationStrategy {
 }
 
 pub struct NoneAuthentication {}
+
+impl NoneAuthentication {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for NoneAuthentication {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl AuthenticationStrategy for NoneAuthentication {
     fn authenticate(self) -> HeaderMap {

--- a/flipt-rust/src/lib.rs
+++ b/flipt-rust/src/lib.rs
@@ -46,6 +46,14 @@ pub trait AuthenticationStrategy {
     fn authenticate(self) -> HeaderMap;
 }
 
+pub struct NoneAuthentication {}
+
+impl AuthenticationStrategy for NoneAuthentication {
+    fn authenticate(self) -> HeaderMap {
+        HeaderMap::new()
+    }
+}
+
 pub struct JWTAuthentication {
     jwt_token: String,
 }

--- a/flipt-rust/tests/integration.rs
+++ b/flipt-rust/tests/integration.rs
@@ -3,7 +3,7 @@ use flipt::evaluation::models::{
     BatchEvaluationRequest, ErrorEvaluationReason, EvaluationReason, EvaluationRequest,
     EvaluationResponseType,
 };
-use flipt::{AuthScheme, Config};
+use flipt::{ClientTokenAuthentication, Config};
 use std::{collections::HashMap, env};
 use url::Url;
 
@@ -14,7 +14,7 @@ async fn tests() {
 
     let flipt_client = FliptClient::new(Config::new(
         Url::parse(&url).unwrap(),
-        AuthScheme::BearerToken(token),
+        ClientTokenAuthentication::new(token),
         60,
     ))
     .unwrap();


### PR DESCRIPTION
In the other SDKs we are generalizing the `AuthenticationStrategy` as we might support more in the future, and the semantics of how they can get generated can vary from one to the next.

This PR adds support for generalizing the `AuthenticationStrategy` for the rust client.

Closes: https://github.com/flipt-io/flipt-server-sdks/issues/64.