### PR TITLE
chore(java): make method names consistent before 1.0.0 release

### DIFF
--- a/flipt-java/src/main/java/example/Main.java
+++ b/flipt-java/src/main/java/example/Main.java
@@ -40,7 +40,7 @@ public class Main {
     evaluationRequests.add(errorEvaluationRequest);
 
     VariantEvaluationResponse variantEvaluationResponse =
-        fliptClient.evaluation().variant(variantEvaluationRequest);
+        fliptClient.evaluation().variantEvaluation(variantEvaluationRequest);
 
     BooleanEvaluationResponse booleanEvaluationResponse =
         fliptClient.evaluation().booleanEvaluation(booleanEvaluationRequest);
@@ -48,6 +48,6 @@ public class Main {
     BatchEvaluationResponse batchEvaluationResponse =
         fliptClient
             .evaluation()
-            .batch(BatchEvaluationRequest.builder().requests(evaluationRequests).build());
+            .batchEvaluation(BatchEvaluationRequest.builder().requests(evaluationRequests).build());
   }
 }

--- a/flipt-java/src/main/java/io/flipt/api/evaluation/Evaluation.java
+++ b/flipt-java/src/main/java/io/flipt/api/evaluation/Evaluation.java
@@ -30,7 +30,7 @@ public class Evaluation {
             .build();
   }
 
-  public VariantEvaluationResponse variant(EvaluationRequest request) {
+  public VariantEvaluationResponse variantEvaluation(EvaluationRequest request) {
     URL url;
 
     try {
@@ -100,7 +100,7 @@ public class Evaluation {
     }
   }
 
-  public BatchEvaluationResponse batch(BatchEvaluationRequest request) {
+  public BatchEvaluationResponse batchEvaluation(BatchEvaluationRequest request) {
     RequestBody body;
 
     try {

--- a/flipt-java/src/test/java/TestFliptClient.java
+++ b/flipt-java/src/test/java/TestFliptClient.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestFliptClient {
   @Test
-  void testVariant() {
+  void testVariantEvaluation() {
     String fliptURL = System.getenv().get("FLIPT_URL");
     String authToken = System.getenv().get("FLIPT_AUTH_TOKEN");
 
@@ -25,7 +25,7 @@ public class TestFliptClient {
     context.put("fizz", "buzz");
     VariantEvaluationResponse variant =
         fc.evaluation()
-            .variant(
+            .variantEvaluation(
                 new EvaluationRequest("default", "flag1", "entity", context, Optional.empty()));
 
     Assertions.assertTrue(variant.isMatch());
@@ -36,7 +36,7 @@ public class TestFliptClient {
   }
 
   @Test
-  void testBoolean() {
+  void testBooleanEvaluation() {
     String fliptURL = System.getenv().get("FLIPT_URL");
     String authToken = System.getenv().get("FLIPT_AUTH_TOKEN");
 
@@ -64,7 +64,7 @@ public class TestFliptClient {
   }
 
   @Test
-  void testBatch() {
+  void testBatchEvaluation() {
     String fliptURL = System.getenv().get("FLIPT_URL");
     String authToken = System.getenv().get("FLIPT_AUTH_TOKEN");
 
@@ -94,7 +94,7 @@ public class TestFliptClient {
 
     BatchEvaluationResponse batch =
         fc.evaluation()
-            .batch(
+            .batchEvaluation(
                 new BatchEvaluationRequest(Optional.of(""), evaluationRequests, Optional.empty()));
 
     // Variant


### PR DESCRIPTION
lets just make all the java method names consistent and have `Evaluation` on the end