### PR TITLE
chore(flipt-rust): remove dead code, and get example working with reference

### DIFF
--- a/flipt-rust/examples/evaluations.rs
+++ b/flipt-rust/examples/evaluations.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             flag_key: "flag1".into(),
             entity_id: "entity".into(),
             context: context.clone(),
+            reference: None,
         })
         .await
         .unwrap();
@@ -34,6 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             flag_key: "flag_boolean".into(),
             entity_id: "entity".into(),
             context: context.clone(),
+            reference: None,
         })
         .await
         .unwrap();
@@ -46,18 +48,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             flag_key: "flag1".into(),
             entity_id: "entity".into(),
             context: context.clone(),
+            reference: None,
         },
         EvaluationRequest {
             namespace_key: "default".into(),
             flag_key: "flag_boolean".into(),
             entity_id: "entity".into(),
             context: context.clone(),
+            reference: None,
         },
     ];
 
     let batch_result = client
         .evaluation
-        .batch(&BatchEvaluationRequest { requests })
+        .batch(&BatchEvaluationRequest {
+            requests,
+            reference: None,
+        })
         .await
         .unwrap();
 

--- a/flipt-rust/src/lib.rs
+++ b/flipt-rust/src/lib.rs
@@ -108,16 +108,3 @@ impl AuthenticationStrategy for ClientTokenAuthentication {
         header_map
     }
 }
-
-#[derive(Debug, Clone)]
-pub enum AuthScheme {
-    None,
-    BearerToken(String),
-    JWT(String),
-}
-
-impl Default for AuthScheme {
-    fn default() -> Self {
-        Self::None
-    }
-}


### PR DESCRIPTION
Remove the dead code in regards to `AuthScheme`, and add `reference` field to all examples to get it compiling again.