### PR TITLE
feat(python): add get_flag method

### DIFF
--- a/.github/workflows/lint-sdks.yml
+++ b/.github/workflows/lint-sdks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.7.0
+          version: 1.7.1
 
       - name: Lint Python source
         working-directory: flipt-python

--- a/flipt-python/Makefile
+++ b/flipt-python/Makefile
@@ -1,9 +1,9 @@
 format:
-	poetry run ruff flipt tests --fix
+	poetry run ruff check flipt tests --fix
 	poetry run black flipt tests
 
 lint:
-	poetry run ruff flipt tests
+	poetry run ruff check flipt tests
 	poetry run black flipt tests --check
 	poetry run mypy flipt
 	poetry run pytest --dead-fixtures

--- a/flipt-python/README.md
+++ b/flipt-python/README.md
@@ -43,3 +43,5 @@ There is a more detailed example in the [examples](./examples) directory.
 
 After adding new code, please don't forget to add unit tests for new features.
 To format the code, check it with linters and run tests, use the `make check` command. 
+
+Please keep the Python [PEP8](https://peps.python.org/pep-0008/) in mind while adding new code.

--- a/flipt-python/flipt/__init__.py
+++ b/flipt-python/flipt/__init__.py
@@ -2,6 +2,6 @@ from .async_client import AsyncFliptClient
 from .sync_client import FliptClient
 
 __all__ = [
-    'FliptClient',
-    'AsyncFliptClient',
+    "FliptClient",
+    "AsyncFliptClient",
 ]

--- a/flipt-python/flipt/authentication/__init__.py
+++ b/flipt-python/flipt/authentication/__init__.py
@@ -1,6 +1,6 @@
 class AuthenticationStrategy:
     def authenticate(self, headers: dict[str, str]) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class ClientTokenAuthentication(AuthenticationStrategy):

--- a/flipt-python/flipt/evaluation/__init__.py
+++ b/flipt-python/flipt/evaluation/__init__.py
@@ -14,16 +14,16 @@ from .models import (
 from .sync_evaluation_client import Evaluation
 
 __all__ = [
-    'Evaluation',
-    'AsyncEvaluation',
-    'EvaluationResponseType',
-    'EvaluationReason',
-    'ErrorEvaluationReason',
-    'EvaluationRequest',
-    'BatchEvaluationRequest',
-    'VariantEvaluationResponse',
-    'BooleanEvaluationResponse',
-    'ErrorEvaluationResponse',
-    'EvaluationResponse',
-    'BatchEvaluationResponse',
+    "Evaluation",
+    "AsyncEvaluation",
+    "EvaluationResponseType",
+    "EvaluationReason",
+    "ErrorEvaluationReason",
+    "EvaluationRequest",
+    "BatchEvaluationRequest",
+    "VariantEvaluationResponse",
+    "BooleanEvaluationResponse",
+    "ErrorEvaluationResponse",
+    "EvaluationResponse",
+    "BatchEvaluationResponse",
 ]

--- a/flipt-python/flipt/evaluation/async_evaluation_client.py
+++ b/flipt-python/flipt/evaluation/async_evaluation_client.py
@@ -2,8 +2,9 @@ from http import HTTPStatus
 
 import httpx
 
-from ..authentication import AuthenticationStrategy
-from ..exceptions import FliptApiError
+from flipt.authentication import AuthenticationStrategy
+from flipt.exceptions import FliptApiError
+
 from .models import (
     BatchEvaluationRequest,
     BatchEvaluationResponse,
@@ -31,6 +32,12 @@ class AsyncEvaluation:
     async def close(self) -> None:
         await self._client.aclose()
 
+    def _raise_on_error(self, response: httpx.Response) -> None:
+        if response.status_code != 200:
+            body = response.json()
+            message = body.get("message", HTTPStatus(response.status_code).description)
+            raise FliptApiError(message, response.status_code)
+
     async def variant(self, request: EvaluationRequest) -> VariantEvaluationResponse:
         response = await self._client.post(
             f"{self.url}/evaluate/v1/variant",
@@ -38,11 +45,7 @@ class AsyncEvaluation:
             json=request.model_dump(),
         )
 
-        if response.status_code != 200:
-            body = response.json()
-            message = body.get("message", HTTPStatus(response.status_code).description)
-            raise FliptApiError(message, response.status_code)
-
+        self._raise_on_error(response)
         return VariantEvaluationResponse.model_validate_json(response.text)
 
     async def boolean(self, request: EvaluationRequest) -> BooleanEvaluationResponse:
@@ -52,11 +55,7 @@ class AsyncEvaluation:
             json=request.model_dump(),
         )
 
-        if response.status_code != 200:
-            body = response.json()
-            message = body.get("message", HTTPStatus(response.status_code).description)
-            raise FliptApiError(message, response.status_code)
-
+        self._raise_on_error(response)
         return BooleanEvaluationResponse.model_validate_json(response.text)
 
     async def batch(self, request: BatchEvaluationRequest) -> BatchEvaluationResponse:
@@ -66,9 +65,5 @@ class AsyncEvaluation:
             json=request.model_dump(),
         )
 
-        if response.status_code != 200:
-            body = response.json()
-            message = body.get("message", HTTPStatus(response.status_code).description)
-            raise FliptApiError(message, response.status_code)
-
+        self._raise_on_error(response)
         return BatchEvaluationResponse.model_validate_json(response.text)

--- a/flipt-python/flipt/flags/async_flag_client.py
+++ b/flipt-python/flipt/flags/async_flag_client.py
@@ -2,13 +2,11 @@ from http import HTTPStatus
 
 import httpx
 
-from flipt.models import ListParameters
+from flipt.authentication import AuthenticationStrategy
+from flipt.exceptions import FliptApiError
+from flipt.models import CommonParameters, ListParameters
 
-from ..authentication import AuthenticationStrategy
-from ..exceptions import FliptApiError
-from .models import (
-    ListFlagsResponse,
-)
+from .models import Flag, ListFlagsResponse
 
 
 class AsyncFlag:
@@ -35,11 +33,20 @@ class AsyncFlag:
             message = body.get("message", HTTPStatus(response.status_code).description)
             raise FliptApiError(message, response.status_code)
 
-    async def list_flags(self, *, namespace_key: str, params: ListParameters | None = None) -> ListFlagsResponse:
+    async def list_flags(self, namespace_key: str, params: ListParameters | None = None) -> ListFlagsResponse:
         response = await self._client.get(
             f"{self.url}/api/v1/namespaces/{namespace_key}/flags",
-            params=params.model_dump_json(exclude_none=True) if params else {},
+            params=params.model_dump_json(exclude_none=True, by_alias=True) if params else {},
             headers=self.headers,
         )
         self._raise_on_error(response)
         return ListFlagsResponse.model_validate_json(response.text)
+
+    async def get_flag(self, namespace_key: str, flag_key: str, params: CommonParameters | None = None) -> Flag:
+        response = await self._client.get(
+            f"{self.url}/api/v1/namespaces/{namespace_key}/flags/{flag_key}",
+            params=params.model_dump_json(exclude_none=True, by_alias=True) if params else {},
+            headers=self.headers,
+        )
+        self._raise_on_error(response)
+        return Flag.model_validate_json(response.text)

--- a/flipt-python/flipt/flags/models.py
+++ b/flipt-python/flipt/flags/models.py
@@ -1,26 +1,37 @@
 from datetime import datetime
-from enum import Enum
-from typing import Any
+from enum import StrEnum
 
 from flipt.models import CamelAliasModel, PaginatedResponse
 
 
-class FlagType(str, Enum):
+class FlagType(StrEnum):
     variant = "VARIANT_FLAG_TYPE"
     boolean = "BOOLEAN_FLAG_TYPE"
 
 
-class Flag(CamelAliasModel):
-    created_at: datetime
+class Variant(CamelAliasModel):
+    attachment: str
     description: str
-    enabled: bool
+    flag_key: str
+    id: str
     key: str
     name: str
-    namespacekey: str | None = None
+    namespace_key: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class Flag(CamelAliasModel):
+    key: str
+    name: str
+    description: str
+    enabled: bool
+    namespace_key: str
     type: FlagType
-    updatedAt: datetime
-    variants: list[Any]
+    created_at: datetime
+    updated_at: datetime
+    variants: list[Variant]
 
 
-class ListFlagsResponse(CamelAliasModel, PaginatedResponse):
+class ListFlagsResponse(PaginatedResponse):
     flags: list[Flag]

--- a/flipt-python/flipt/models.py
+++ b/flipt-python/flipt/models.py
@@ -9,13 +9,16 @@ class CamelAliasModel(BaseModel):
     )
 
 
-class ListParameters(BaseModel):
-    limit: int | None = None
-    offset: int | None = None
-    pageToken: str | None = None
+class CommonParameters(CamelAliasModel):
     reference: str | None = None
 
 
-class PaginatedResponse(BaseModel):
-    nextPageToken: str
-    totalCount: int
+class ListParameters(CommonParameters):
+    limit: int | None = None
+    offset: int | None = None
+    page_token: str | None = None
+
+
+class PaginatedResponse(CamelAliasModel):
+    next_page_token: str
+    total_count: int

--- a/flipt-python/pyproject.toml
+++ b/flipt-python/pyproject.toml
@@ -63,22 +63,65 @@ skip_covered = true
 source = ["flipt"]
 branch = true
 
+[tool.ruff]
+line-length = 120
+
 [tool.ruff.lint]
 exclude = [".git", ".venv"]
 select = [
+    "A",
     "ARG",
     "B",
+    "BLE",
     "C",
     "C4",
+    "C90",
+    "COM",
+    "D",
+    "DTZ",
     "E",
+    "ERA",
+    "EXE",
     "F",
+    "G",
     "I",
+    "ICN",
+    "INP",
+    "ISC",
+    "N",
+    "PD",
+    "PIE",
     "PL",
     "PT",
     "T",
+    "PTH",
+    "Q",
+    "RET",
+    "RSE",
+    "RUF",
+    "S",
+    "SIM",
+    "T10",
+    "T20",
+    "TCH",
+    "TID",
     "W",
+    "YTT",
 ]
-ignore = ["E501", "PLR2004"]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D203",
+    "D213",
+    "S101",
+    "PLR2004",
+]
 
 [tool.ruff.lint.pylint]
 max-args = 5

--- a/flipt-python/tests/evaluation/conftest.py
+++ b/flipt-python/tests/evaluation/conftest.py
@@ -3,31 +3,31 @@ from http import HTTPStatus
 import pytest
 
 
-@pytest.fixture(params=[{}, {'message': 'some error'}])
+@pytest.fixture(params=[{}, {"message": "some error"}])
 def _mock_variant_response_error(httpx_mock, flipt_url, request):
     httpx_mock.add_response(
         method="POST",
-        url=f'{flipt_url}/evaluate/v1/variant',
+        url=f"{flipt_url}/evaluate/v1/variant",
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         json=request.param,
     )
 
 
-@pytest.fixture(params=[{}, {'message': 'some error'}])
+@pytest.fixture(params=[{}, {"message": "some error"}])
 def _mock_boolean_response_error(httpx_mock, flipt_url, request):
     httpx_mock.add_response(
         method="POST",
-        url=f'{flipt_url}/evaluate/v1/boolean',
+        url=f"{flipt_url}/evaluate/v1/boolean",
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         json=request.param,
     )
 
 
-@pytest.fixture(params=[{}, {'message': 'some error'}])
+@pytest.fixture(params=[{}, {"message": "some error"}])
 def _mock_batch_response_error(httpx_mock, flipt_url, request):
     httpx_mock.add_response(
         method="POST",
-        url=f'{flipt_url}/evaluate/v1/batch',
+        url=f"{flipt_url}/evaluate/v1/batch",
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         json=request.param,
     )

--- a/flipt-python/tests/evaluation/test_async_client.py
+++ b/flipt-python/tests/evaluation/test_async_client.py
@@ -11,17 +11,17 @@ async def test_variant(async_flipt_client):
             flag_key="flag1",
             entity_id="entity",
             context={"fizz": "buzz"},
-        )
+        ),
     )
 
     assert variant.match
-    assert variant.flag_key == 'flag1'
-    assert variant.variant_key == 'variant1'
-    assert variant.reason == 'MATCH_EVALUATION_REASON'
-    assert 'segment1' in variant.segment_keys
+    assert variant.flag_key == "flag1"
+    assert variant.variant_key == "variant1"
+    assert variant.reason == "MATCH_EVALUATION_REASON"
+    assert "segment1" in variant.segment_keys
 
 
-@pytest.mark.usefixtures('_mock_variant_response_error')
+@pytest.mark.usefixtures("_mock_variant_response_error")
 async def test_evaluate_variant_error(async_flipt_client):
     with pytest.raises(FliptApiError):
         await async_flipt_client.evaluation.variant(
@@ -30,7 +30,7 @@ async def test_evaluate_variant_error(async_flipt_client):
                 flag_key="flag1",
                 entity_id="entity",
                 context={"fizz": "buzz"},
-            )
+            ),
         )
 
 
@@ -41,15 +41,15 @@ async def test_boolean(async_flipt_client):
             flag_key="flag_boolean",
             entity_id="entity",
             context={"fizz": "buzz"},
-        )
+        ),
     )
 
     assert boolean.enabled
-    assert boolean.flag_key == 'flag_boolean'
-    assert boolean.reason == 'MATCH_EVALUATION_REASON'
+    assert boolean.flag_key == "flag_boolean"
+    assert boolean.reason == "MATCH_EVALUATION_REASON"
 
 
-@pytest.mark.usefixtures('_mock_boolean_response_error')
+@pytest.mark.usefixtures("_mock_boolean_response_error")
 async def test_evaluate_boolean_error(async_flipt_client):
     with pytest.raises(FliptApiError):
         await async_flipt_client.evaluation.boolean(
@@ -58,7 +58,7 @@ async def test_evaluate_boolean_error(async_flipt_client):
                 flag_key="flag_boolean",
                 entity_id="entity",
                 context={"fizz": "buzz"},
-            )
+            ),
         )
 
 
@@ -84,8 +84,8 @@ async def test_batch(async_flipt_client):
                     entity_id="entity",
                     context={"fizz": "buzz"},
                 ),
-            ]
-        )
+            ],
+        ),
     )
 
     assert len(batch.responses) == 3
@@ -98,10 +98,10 @@ async def test_batch(async_flipt_client):
     assert variant.flag_key == "flag1"
     assert variant.variant_key == "variant1"
     assert variant.reason == "MATCH_EVALUATION_REASON"
-    assert 'segment1' in variant.segment_keys
+    assert "segment1" in variant.segment_keys
 
     # Boolean
-    assert batch.responses[1].type == 'BOOLEAN_EVALUATION_RESPONSE_TYPE'
+    assert batch.responses[1].type == "BOOLEAN_EVALUATION_RESPONSE_TYPE"
 
     boolean = batch.responses[1].boolean_response
     assert boolean.enabled
@@ -109,7 +109,7 @@ async def test_batch(async_flipt_client):
     assert boolean.reason == "MATCH_EVALUATION_REASON"
 
     # Error
-    assert batch.responses[2].type == 'ERROR_EVALUATION_RESPONSE_TYPE'
+    assert batch.responses[2].type == "ERROR_EVALUATION_RESPONSE_TYPE"
 
     error = batch.responses[2].error_response
     assert error.flag_key == "notfound"
@@ -117,7 +117,7 @@ async def test_batch(async_flipt_client):
     assert error.reason == "NOT_FOUND_ERROR_EVALUATION_REASON"
 
 
-@pytest.mark.usefixtures('_mock_batch_response_error')
+@pytest.mark.usefixtures("_mock_batch_response_error")
 async def test_evaluate_batch_error(async_flipt_client):
     with pytest.raises(FliptApiError):
         await async_flipt_client.evaluation.batch(
@@ -141,6 +141,6 @@ async def test_evaluate_batch_error(async_flipt_client):
                         entity_id="entity",
                         context={"fizz": "buzz"},
                     ),
-                ]
-            )
+                ],
+            ),
         )

--- a/flipt-python/tests/evaluation/test_sync_client.py
+++ b/flipt-python/tests/evaluation/test_sync_client.py
@@ -11,17 +11,17 @@ def test_variant(sync_flipt_client):
             flag_key="flag1",
             entity_id="entity",
             context={"fizz": "buzz"},
-        )
+        ),
     )
 
     assert variant.match
-    assert variant.flag_key == 'flag1'
-    assert variant.variant_key == 'variant1'
-    assert variant.reason == 'MATCH_EVALUATION_REASON'
-    assert 'segment1' in variant.segment_keys
+    assert variant.flag_key == "flag1"
+    assert variant.variant_key == "variant1"
+    assert variant.reason == "MATCH_EVALUATION_REASON"
+    assert "segment1" in variant.segment_keys
 
 
-@pytest.mark.usefixtures('_mock_variant_response_error')
+@pytest.mark.usefixtures("_mock_variant_response_error")
 def test_evaluate_variant_error(sync_flipt_client):
     with pytest.raises(FliptApiError):
         sync_flipt_client.evaluation.variant(
@@ -30,7 +30,7 @@ def test_evaluate_variant_error(sync_flipt_client):
                 flag_key="flag1",
                 entity_id="entity",
                 context={"fizz": "buzz"},
-            )
+            ),
         )
 
 
@@ -41,15 +41,15 @@ def test_boolean(sync_flipt_client):
             flag_key="flag_boolean",
             entity_id="entity",
             context={"fizz": "buzz"},
-        )
+        ),
     )
 
     assert boolean.enabled
-    assert boolean.flag_key == 'flag_boolean'
-    assert boolean.reason == 'MATCH_EVALUATION_REASON'
+    assert boolean.flag_key == "flag_boolean"
+    assert boolean.reason == "MATCH_EVALUATION_REASON"
 
 
-@pytest.mark.usefixtures('_mock_boolean_response_error')
+@pytest.mark.usefixtures("_mock_boolean_response_error")
 def test_evaluate_boolean_error(sync_flipt_client):
     with pytest.raises(FliptApiError):
         sync_flipt_client.evaluation.boolean(
@@ -58,7 +58,7 @@ def test_evaluate_boolean_error(sync_flipt_client):
                 flag_key="flag_boolean",
                 entity_id="entity",
                 context={"fizz": "buzz"},
-            )
+            ),
         )
 
 
@@ -84,8 +84,8 @@ def test_batch(sync_flipt_client):
                     entity_id="entity",
                     context={"fizz": "buzz"},
                 ),
-            ]
-        )
+            ],
+        ),
     )
 
     assert len(batch.responses) == 3
@@ -98,10 +98,10 @@ def test_batch(sync_flipt_client):
     assert variant.flag_key == "flag1"
     assert variant.variant_key == "variant1"
     assert variant.reason == "MATCH_EVALUATION_REASON"
-    assert 'segment1' in variant.segment_keys
+    assert "segment1" in variant.segment_keys
 
     # Boolean
-    assert batch.responses[1].type == 'BOOLEAN_EVALUATION_RESPONSE_TYPE'
+    assert batch.responses[1].type == "BOOLEAN_EVALUATION_RESPONSE_TYPE"
 
     boolean = batch.responses[1].boolean_response
     assert boolean.enabled
@@ -109,7 +109,7 @@ def test_batch(sync_flipt_client):
     assert boolean.reason == "MATCH_EVALUATION_REASON"
 
     # Error
-    assert batch.responses[2].type == 'ERROR_EVALUATION_RESPONSE_TYPE'
+    assert batch.responses[2].type == "ERROR_EVALUATION_RESPONSE_TYPE"
 
     error = batch.responses[2].error_response
     assert error.flag_key == "notfound"
@@ -117,7 +117,7 @@ def test_batch(sync_flipt_client):
     assert error.reason == "NOT_FOUND_ERROR_EVALUATION_REASON"
 
 
-@pytest.mark.usefixtures('_mock_batch_response_error')
+@pytest.mark.usefixtures("_mock_batch_response_error")
 def test_evaluate_batch_error(sync_flipt_client):
     with pytest.raises(FliptApiError):
         sync_flipt_client.evaluation.batch(
@@ -141,6 +141,6 @@ def test_evaluate_batch_error(sync_flipt_client):
                         entity_id="entity",
                         context={"fizz": "buzz"},
                     ),
-                ]
-            )
+                ],
+            ),
         )

--- a/flipt-python/tests/flag/conftest.py
+++ b/flipt-python/tests/flag/conftest.py
@@ -3,11 +3,11 @@ from http import HTTPStatus
 import pytest
 
 
-@pytest.fixture(params=[{}, {'message': 'some error'}])
+@pytest.fixture(params=[{}, {"message": "some error"}])
 def _mock_list_flags_response_error(httpx_mock, flipt_url, request):
     httpx_mock.add_response(
         method="GET",
-        url=f'{flipt_url}/api/v1/namespaces/default/flags',
+        url=f"{flipt_url}/api/v1/namespaces/default/flags",
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         json=request.param,
     )

--- a/flipt-python/tests/flag/test_async_client.py
+++ b/flipt-python/tests/flag/test_async_client.py
@@ -5,11 +5,20 @@ from flipt.exceptions import FliptApiError
 
 
 class TestListFlags:
-    async def test_success(self, async_flipt_client: AsyncFliptClient):
+    async def test_list_flags_success(self, async_flipt_client: AsyncFliptClient):
         list_response = await async_flipt_client.flag.list_flags(namespace_key="default")
         assert len(list_response.flags) == 2
 
     @pytest.mark.usefixtures("_mock_list_flags_response_error")
-    async def test_list_error(self, async_flipt_client):
+    async def test_list_flags_error(self, async_flipt_client):
         with pytest.raises(FliptApiError):
             await async_flipt_client.flag.list_flags(namespace_key="default")
+
+    @pytest.mark.parametrize("flag_key", ["flag1", "flag_boolean"])
+    async def test_get_flag_success(self, async_flipt_client, flag_key):
+        flag = await async_flipt_client.flag.get_flag("default", flag_key)
+        assert flag.key == flag_key
+
+    async def test_get_flag_error(self, async_flipt_client):
+        with pytest.raises(FliptApiError):
+            await async_flipt_client.flag.get_flag("default", "notfound")

--- a/flipt-python/tests/flag/test_sync_client.py
+++ b/flipt-python/tests/flag/test_sync_client.py
@@ -4,11 +4,20 @@ from flipt.exceptions import FliptApiError
 
 
 class TestListFlags:
-    def test_success(self, sync_flipt_client):
+    def test_list_flags_success(self, sync_flipt_client):
         list_response = sync_flipt_client.flag.list_flags(namespace_key="default")
         assert len(list_response.flags) == 2
 
     @pytest.mark.usefixtures("_mock_list_flags_response_error")
-    def test_list_error(self, sync_flipt_client):
+    def test_list_flags_error(self, sync_flipt_client):
         with pytest.raises(FliptApiError):
             sync_flipt_client.flag.list_flags(namespace_key="default")
+
+    @pytest.mark.parametrize("flag_key", ["flag1", "flag_boolean"])
+    def test_get_flag_success(self, sync_flipt_client, flag_key):
+        flag = sync_flipt_client.flag.get_flag("default", flag_key)
+        assert flag.key == flag_key
+
+    def test_get_flag_error(self, sync_flipt_client):
+        with pytest.raises(FliptApiError):
+            sync_flipt_client.flag.get_flag("default", "notfound")

--- a/test/main.go
+++ b/test/main.go
@@ -102,14 +102,14 @@ func getTestDependencies(ctx context.Context, client *dagger.Client, dir *dagger
 // pythonTests runs the python integration test suite against a container running Flipt.
 func pythonTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, hostDirectory *dagger.Directory) error {
 	_, err := client.Container().From("python:3.11-bookworm").
-		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
+		WithExec([]string{"pip", "install", "poetry==1.7.1"}).
 		WithWorkdir("/src").
 		WithDirectory("/src", hostDirectory.Directory("flipt-python")).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
 		WithExec([]string{"poetry", "install"}).
-		WithExec([]string{"poetry", "run", "test"}).
+		WithExec([]string{"make", "test"}).
 		Sync(ctx)
 
 	return err


### PR DESCRIPTION
In this PR, I have added support for the `get_flag` API. I have also fixed several issues that violated PEP8 and added new rules for Ruff. 

We use this API to get a specific flag, because it is expensive to request all flags when there are many of them. In our case, we sometimes need to get a single specific flag and don't want to get a list and sift through them all.

If there are actually no plans to implement this feature in the SDK, please let me know so I will remove these changes from the PR and keep the code style edits. If you do not think this is necessary, please let me know, and I will close this PR.