### PR TITLE
Fix incorrect variable reference in PHP SDK

### DIFF
--- a/flipt-php/src/Flipt/Client/FliptClient.php
+++ b/flipt-php/src/Flipt/Client/FliptClient.php
@@ -90,7 +90,7 @@ final class FliptClient
             'entityId' => isset($entityId) ? $entityId : $this->entityId,
             'flagKey' => $name,
             'namespaceKey' => $this->namespace,
-            'reference' => $this->reference,
+            'reference' => $reference,
         ];
     }
 


### PR DESCRIPTION
This PR fixes what appears to be a small oversight in the PHP SDK source code, resulting in the following warnings when using the `FliptClient`:

> **Warning**:  Undefined property: Flipt\Client\FliptClient::$reference in **/app/vendor/flipt-io/flipt/src/Flipt/Client/FliptClient.php** on line **93**