### PR TITLE
rust: reexport `url::Url`

### DIFF
--- a/flipt-rust/src/lib.rs
+++ b/flipt-rust/src/lib.rs
@@ -5,7 +5,8 @@ pub mod util;
 
 use reqwest::header::HeaderMap;
 use std::time::Duration;
-use url::Url;
+// reexport
+pub use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct Config<T>


### PR DESCRIPTION
flipt-rust has some interfaces taking values with type `url::Url`.
However, it does not export the type.

https://github.com/flipt-io/flipt-server-sdks/blob/90ed038b834b1416256a4e4c15bae9ba89437553/flipt-rust/src/lib.rs#L15