### PR TITLE
doc(): fix wrong link

### DIFF
--- a/flipt-java/README.md
+++ b/flipt-java/README.md
@@ -58,4 +58,4 @@ public class Main {
     EvaluationResponse variantEvaluationResponse = fliptClient.evaluate(variantEvaluationRequest);
 ```
 
-There is a more detailed example in the [examples](./examples) directory.
+There is a more detailed example in the [examples](./src/main/java/examples) directory.


### PR DESCRIPTION
## Description
* Adjust the link to the examples folder -- relative path --

## How to review?
* Check that the current link must have been pasted from previous repo, and it does NOT work