### PR TITLE
fix: resolve GitHub 3-tag limitation in release workflows

### DIFF
--- a/.github/workflows/package-csharp-sdk.yml
+++ b/.github/workflows/package-csharp-sdk.yml
@@ -2,6 +2,12 @@ name: Package C# SDK
 on:
   push:
     tags: ["flipt-csharp-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-csharp-v0.1.1). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -14,4 +20,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: csharp
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/package-java-sdk.yml
+++ b/.github/workflows/package-java-sdk.yml
@@ -2,6 +2,12 @@ name: Package Java SDK
 on:
   push:
     tags: ["flipt-java-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-java-v1.3.0). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -18,4 +24,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: java
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/package-node-sdk.yml
+++ b/.github/workflows/package-node-sdk.yml
@@ -2,6 +2,12 @@ name: Package Node SDK
 on:
   push:
     tags: ["flipt-node-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-node-v1.3.0). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -14,4 +20,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: node
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/package-php-sdk.yml
+++ b/.github/workflows/package-php-sdk.yml
@@ -2,6 +2,12 @@ name: Package PHP SDK
 on:
   push:
     tags: ["flipt-php-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-php-v1.2.0). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -11,5 +17,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: php
-      tag: ${{ github.ref }}
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/package-python-sdk.yml
+++ b/.github/workflows/package-python-sdk.yml
@@ -2,6 +2,12 @@ name: Package Python SDK
 on:
   push:
     tags: ["flipt-python-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-python-v1.5.0). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -14,4 +20,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: python
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/package-rust-sdk.yml
+++ b/.github/workflows/package-rust-sdk.yml
@@ -2,6 +2,12 @@ name: Package Rust SDK
 on:
   push:
     tags: ["flipt-rust-**"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to package (e.g., flipt-rust-v1.2.0). Leave empty to use latest tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -14,4 +20,5 @@ jobs:
     uses: ./.github/workflows/package-sdks.yml
     with:
       sdk: rust
+      tag: ${{ inputs.tag || github.ref }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,20 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      python_released: ${{ steps.release.outputs['flipt-python--release_created'] }}
+      node_released: ${{ steps.release.outputs['flipt-node--release_created'] }}
+      java_released: ${{ steps.release.outputs['flipt-java--release_created'] }}
+      rust_released: ${{ steps.release.outputs['flipt-rust--release_created'] }}
+      php_released: ${{ steps.release.outputs['flipt-php--release_created'] }}
+      csharp_released: ${{ steps.release.outputs['flipt-csharp--release_created'] }}
+      python_tag: ${{ steps.release.outputs['flipt-python--tag_name'] }}
+      node_tag: ${{ steps.release.outputs['flipt-node--tag_name'] }}
+      java_tag: ${{ steps.release.outputs['flipt-java--tag_name'] }}
+      rust_tag: ${{ steps.release.outputs['flipt-rust--tag_name'] }}
+      php_tag: ${{ steps.release.outputs['flipt-php--tag_name'] }}
+      csharp_tag: ${{ steps.release.outputs['flipt-csharp--tag_name'] }}
     steps:
       - name: Generate token
         id: generate_token
@@ -21,5 +35,60 @@ jobs:
           installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
 
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ steps.generate_token.outputs.token}}
+
+  trigger-python-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.python_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: python
+      tag: ${{ needs.release-please.outputs.python_tag }}
+    secrets: inherit
+
+  trigger-node-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.node_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: node
+      tag: ${{ needs.release-please.outputs.node_tag }}
+    secrets: inherit
+
+  trigger-java-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.java_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: java
+      tag: ${{ needs.release-please.outputs.java_tag }}
+    secrets: inherit
+
+  trigger-rust-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.rust_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: rust
+      tag: ${{ needs.release-please.outputs.rust_tag }}
+    secrets: inherit
+
+  trigger-php-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.php_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: php
+      tag: ${{ needs.release-please.outputs.php_tag }}
+    secrets: inherit
+
+  trigger-csharp-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.csharp_released == 'true' }}
+    uses: ./.github/workflows/package-sdks.yml
+    with:
+      sdk: csharp
+      tag: ${{ needs.release-please.outputs.csharp_tag }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Fixes the issue where package workflows weren't triggering after Release Please created releases.

## Problem

GitHub Actions does not create workflow events when more than 3 tags are pushed simultaneously. When Release Please created 6 tags at once (python, node, java, rust, php, csharp), **none of the package workflows were triggered**, preventing SDK releases from being published to their respective registries.

## Solution

### 1. Direct Workflow Triggering
- Modified `release-please.yml` to capture Release Please outputs for each SDK
- Added conditional jobs that directly trigger package workflows using job dependencies
- Passes correct tag names from Release Please outputs to each package workflow
- Bypasses the 3-tag limitation entirely

### 2. Manual Workflow Dispatch
- Added `workflow_dispatch` triggers to all package workflows with optional tag input
- Allows manual triggering via GitHub UI or CLI
- Supports recovery from failed releases without re-tagging

## Changes

- **release-please.yml**: Captures outputs and triggers package workflows directly
- **All package-*-sdk.yml**: Added workflow_dispatch with tag input support
- **Tag handling**: All workflows properly pass tags to package-sdks.yml

## Testing

Future releases will automatically trigger package workflows regardless of how many SDKs are released. Manual triggers can be used for the existing releases:

\`\`\`bash
gh workflow run package-python-sdk.yml -f tag=flipt-python-v1.5.0
gh workflow run package-node-sdk.yml -f tag=flipt-node-v1.3.0
# etc.
\`\`\`

Fixes #[issue-number-if-exists]