### PR TITLE
fix(python): make created_at/updated_at optional and deprecated for Flipt v2 support

### DIFF
--- a/flipt-python/flipt/flags/async_flag_client.py
+++ b/flipt-python/flipt/flags/async_flag_client.py
@@ -50,6 +50,7 @@ class AsyncFlag:
         return ListFlagsResponse.model_validate_json(response.text)
 
     async def get_flag(self, namespace_key: str, flag_key: str, params: CommonParameters | None = None) -> Flag:
+        """Flipt v1 only. Not available in Flipt v2."""
         if namespace_key is None:
             namespace_key = "default"
 

--- a/flipt-python/flipt/flags/models.py
+++ b/flipt-python/flipt/flags/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from enum import StrEnum
 
+from pydantic import Field
+
 from flipt.models import CamelAliasModel, PaginatedResponse
 
 
@@ -17,8 +19,14 @@ class Variant(CamelAliasModel):
     key: str
     name: str
     namespace_key: str
-    created_at: datetime
-    updated_at: datetime
+    created_at: datetime | None = Field(
+        default=None,
+        description="Deprecated: populated in Flipt v1, will be None in Flipt v2",
+    )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Deprecated: populated in Flipt v1, will be None in Flipt v2",
+    )
 
 
 class Flag(CamelAliasModel):
@@ -28,8 +36,14 @@ class Flag(CamelAliasModel):
     enabled: bool
     namespace_key: str
     type: FlagType
-    created_at: datetime
-    updated_at: datetime
+    created_at: datetime | None = Field(
+        default=None,
+        description="Deprecated: populated in Flipt v1, will be None in Flipt v2",
+    )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Deprecated: populated in Flipt v1, will be None in Flipt v2",
+    )
     variants: list[Variant]
 
 

--- a/flipt-python/flipt/flags/sync_flag_client.py
+++ b/flipt-python/flipt/flags/sync_flag_client.py
@@ -50,6 +50,7 @@ class SyncFlag:
         return ListFlagsResponse.model_validate_json(response.text)
 
     def get_flag(self, namespace_key: str, flag_key: str, params: CommonParameters | None = None) -> Flag:
+        """Flipt v1 only. Not available in Flipt v2."""
         if namespace_key is None:
             namespace_key = "default"
 


### PR DESCRIPTION
closes #716