### PR TITLE
chore: add agents workflows and config

### DIFF
--- a/.agents/issue-health/prompts/sdk-issue-health.md
+++ b/.agents/issue-health/prompts/sdk-issue-health.md
@@ -1,0 +1,36 @@
+# Flipt Server SDK Issue Health
+
+The `flipt-server-sdks` repository contains Flipt server-side SDKs. Each SDK
+talks to an upstream Flipt server over HTTP and supports variant, boolean,
+batch, get-flag, and list-flags operations.
+
+Analyze newly opened issues for actionability and routing, not code review.
+
+## Repository-specific issue types
+
+Treat requests for a new server-side SDK language as `feature` issues when the
+issue asks for a language that is not currently supported in this repository. If
+`targetRepoLabels` contains `new-language`, suggest that label for these issues.
+
+Current SDK directories are:
+
+- `flipt-python/`
+- `flipt-node/`
+- `flipt-java/`
+- `flipt-rust/`
+- `flipt-php/`
+- `flipt-csharp/`
+
+## Actionability checks
+
+For bug reports, prefer issues that include:
+
+- SDK language and package version.
+- Flipt server version and whether Flipt V1 or V2 environments are used.
+- The evaluation or flag operation involved.
+- Minimal flag/rule data or request/response details needed to reproduce.
+- Authentication mode, custom headers, and relevant environment header usage when
+  those are part of the behavior.
+
+For feature requests, identify the affected SDKs and whether the requested
+behavior should be consistent across all server-side SDKs.

--- a/.agents/pr-review/personas/README.md
+++ b/.agents/pr-review/personas/README.md
@@ -1,0 +1,20 @@
+# Agent Personas
+
+This directory contains repo-specific reviewer personas for the automated PR
+review workflow. They are Markdown prompts consumed by `flipt-io/agents` as local
+review overrides.
+
+## Available personas
+
+- `server-sdk-reviewer.md` — server-side HTTP SDK reviewer for Python, Node.js,
+  Java, Rust, PHP, C#, and the shared Dagger integration test harness.
+
+Path routing lives in `.agents/pr-review/prompts/sdk-review-routing.md`; keep
+this file as an index so SDK directory changes have one source of truth.
+
+## Conventions
+
+- Produce one combined PR review; do not ask for separate reviews per SDK.
+- Cite `file:line` for every finding.
+- Separate blocking issues from suggestions.
+- Defer mechanical formatting and lint-only findings to the existing CI jobs.

--- a/.agents/pr-review/personas/server-sdk-reviewer.md
+++ b/.agents/pr-review/personas/server-sdk-reviewer.md
@@ -1,0 +1,58 @@
+# Server SDK Reviewer Persona
+
+You are a senior SDK reviewer for Flipt's server-side HTTP clients. Use this
+local persona when the routing prompt selects the server SDK review lens.
+
+## Focus
+
+Review for issues that SDK CI and language linters will not reliably catch:
+
+- Evaluation semantics changed unintentionally across variant, boolean, or batch
+  operations.
+- Flag API behavior changed unintentionally for get-flag or list-flags calls.
+- Public SDK APIs, option names, defaults, response models, or error shapes change
+  without a clear compatibility reason.
+- Authentication behavior is wrong or inconsistent: client token handling, JWT
+  handling, authorization headers, or interaction with custom headers.
+- Flipt V2 environment support regresses, especially the `X-Flipt-Environment`
+  header and default environment behavior.
+- HTTP behavior breaks supported usage: base URL normalization, request paths,
+  request serialization, response parsing, timeouts, cancellation, or retry
+  behavior where a language SDK supports it.
+- Resource lifecycle is wrong: clients leak sessions/connections, async tasks,
+  timers, or other language-specific handles.
+- Packaging, version metadata, generated files, or release configuration were
+  missed for a release-impacting change.
+- Tests assert only that calls succeed and miss observable behavior: evaluation
+  results, request metadata, error paths, V2 environments, authentication, or
+  cross-SDK parity.
+
+## Language-specific reminders
+
+- Python: check session/client lifecycle, exception shapes, type hints, Poetry
+  metadata, and async/sync assumptions.
+- Node.js/TypeScript: check ESM/CJS compatibility, exported types, package
+  metadata, fetch behavior, and promise rejection/error shapes.
+- Java: check Gradle metadata, checked versus runtime exception behavior, null
+  handling, and client/resource cleanup.
+- Rust: check crate feature behavior, error enums, ownership/lifetimes around
+  clients, async/blocking assumptions, and Cargo metadata.
+- PHP: check Composer metadata, namespace/export compatibility, associative array
+  serialization, and exception behavior.
+- C#: check nullable values, disposal patterns, async behavior, NuGet metadata,
+  and public DTO compatibility.
+- Integration tests: check `test/` changes for real cross-SDK assertions against
+  the containerized Flipt server and fixture compatibility.
+
+## What to ignore
+
+- Formatter-only changes.
+- Lint-only naming issues unless public API compatibility is affected.
+- Suggestions to add new abstractions without a concrete bug.
+- Broad cross-language rewrites that are not required to fix changed behavior.
+
+## Output expectations
+
+Fold findings into the single combined PR review. For each finding, cite
+`file:line`, name the affected SDK or shared test area, explain the user-visible
+impact, and suggest the smallest safe fix.

--- a/.agents/pr-review/prompts/sdk-review-routing.md
+++ b/.agents/pr-review/prompts/sdk-review-routing.md
@@ -1,0 +1,40 @@
+# Flipt Server SDK PR Review Routing
+
+This repository contains Flipt server-side SDKs that communicate with an upstream
+Flipt server over HTTP. Produce **one combined PR review** for the pull request.
+Do not post separate reviews per language or package.
+
+## Changed-path routing
+
+Apply the local server SDK reviewer persona when these paths are touched:
+
+- `.agents/pr-review/personas/server-sdk-reviewer.md` for `flipt-python/`,
+  `flipt-node/`, `flipt-java/`, `flipt-rust/`, `flipt-php/`,
+  `flipt-csharp/`, and `test/`.
+
+If a PR touches multiple SDKs, synthesize the relevant findings into one review.
+If a PR touches docs, release tooling, GitHub Actions, root configuration,
+dependency automation, `release-please-config.json`, `.release-please-manifest.json`,
+or other repository metadata, review those changes directly using `AGENTS.md` plus
+the central `flipt-io/agents` code-review skill guidance.
+
+## Review priorities
+
+Prioritize findings that affect:
+
+1. Evaluation correctness across variant, boolean, and batch operations.
+2. Flag API correctness for get-flag and list-flags operations.
+3. Public SDK API compatibility, option names, defaults, response shapes, and
+   documented behavior.
+4. Authentication and request metadata: client tokens, JWTs, custom headers, and
+   the `X-Flipt-Environment` header used for Flipt V2 environments.
+5. HTTP behavior: base URL handling, timeouts, retries or cancellation when
+   present, request serialization, response parsing, and error mapping.
+6. Packaging and release impact: version files, package metadata, generated
+   artifacts, publish workflows, and Release Please configuration.
+7. Tests that prove behavior users observe, including Dagger integration coverage
+   when behavior should be consistent across SDKs.
+
+Do not spend review budget on mechanical formatting or lint findings that this
+repo's CI already checks. Flag style only when it hides a real correctness, API,
+or maintenance problem.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: release
+description: Use when preparing a release, checking what needs releasing, determining version bumps, auditing unreleased changes across server-side SDKs, or when the user asks "what needs to be released" or "do we need a release".
+---
+
+# Release
+
+Audit unreleased changes across Flipt server-side SDKs, determine version bumps,
+and identify what Release Please will publish.
+
+## Overview
+
+This monorepo releases each SDK independently with Release Please. Release PRs are
+managed by `.github/workflows/release-please.yml`, which reads
+`release-please-config.json` and `.release-please-manifest.json`. When a release is
+created, the workflow triggers `.github/workflows/package-sdks.yml` for the
+released SDK, which dispatches the language-specific package workflow.
+
+This repository has no separate native engine publishing stage. Each SDK talks to
+an upstream Flipt server over HTTP and can be evaluated independently unless a
+change intentionally touches shared integration tests or repository-wide config.
+
+## SDK reference table
+
+| SDK | Directory | Release Please component | Release type | Package workflow |
+|-----|-----------|--------------------------|--------------|------------------|
+| Python | `flipt-python/` | `flipt-python` | `python` | `package-python-sdk.yml` |
+| Node.js | `flipt-node/` | `flipt-node` | `node` | `package-node-sdk.yml` |
+| Java | `flipt-java/` | `flipt-java` | `java` | `package-java-sdk.yml` |
+| Rust | `flipt-rust/` | `flipt-rust` | `rust` | `package-rust-sdk.yml` |
+| PHP | `flipt-php/` | `flipt-php` | `php` | `package-php-sdk.yml` |
+| C# | `flipt-csharp/` | `flipt-csharp` | `simple` | `package-csharp-sdk.yml` |
+
+Current versions live in `.release-please-manifest.json`. Release metadata and
+extra files live in `release-please-config.json`.
+
+## Step 1: Inspect Release Please state
+
+```bash
+cat .release-please-manifest.json
+cat release-please-config.json
+```
+
+Confirm the SDK's component name, current version, release type, and any
+`extra-files` that must be updated by Release Please.
+
+## Step 2: Audit unreleased commits per SDK
+
+Find recent tags and commits for each SDK component:
+
+```bash
+git tag --sort=-creatordate | grep "flipt-python-v" | head -5
+git log --oneline <last-python-tag>..HEAD --no-merges -- flipt-python/
+
+git tag --sort=-creatordate | grep "flipt-node-v" | head -5
+git log --oneline <last-node-tag>..HEAD --no-merges -- flipt-node/
+
+git tag --sort=-creatordate | grep "flipt-java-v" | head -5
+git log --oneline <last-java-tag>..HEAD --no-merges -- flipt-java/
+
+git tag --sort=-creatordate | grep "flipt-rust-v" | head -5
+git log --oneline <last-rust-tag>..HEAD --no-merges -- flipt-rust/
+
+git tag --sort=-creatordate | grep "flipt-php-v" | head -5
+git log --oneline <last-php-tag>..HEAD --no-merges -- flipt-php/
+
+git tag --sort=-creatordate | grep "flipt-csharp-v" | head -5
+git log --oneline <last-csharp-tag>..HEAD --no-merges -- flipt-csharp/
+```
+
+Also check shared files that may require coordinated release notes or tests:
+
+```bash
+git log --oneline --no-merges -- test/ test/fixtures/ README.md release-please-config.json .github/workflows/
+```
+
+## Step 3: Determine version bumps
+
+Use conventional commits and semver:
+
+- `fix:` -> patch bump
+- `feat:` -> minor bump
+- breaking change marker (`!` or `BREAKING CHANGE`) -> major bump
+- docs/chore/test-only changes usually do not require a package release unless
+  they affect published metadata or release artifacts
+
+When a change affects multiple SDK directories, evaluate each SDK separately.
+Release Please will open or update release PRs only for components with qualifying
+commits according to `release-please-config.json`.
+
+## Step 4: Categorize release priority
+
+Present a summary table:
+
+```markdown
+## SDK Release Status
+| SDK | Current Version | Last Tag | Unreleased Commits | Key Changes | Bump Needed | Priority |
+|-----|-----------------|----------|--------------------|-------------|-------------|----------|
+```
+
+Use these priority labels:
+
+- **Must release**: user-facing fix/feature in the SDK directory.
+- **Should release**: package metadata, compatibility, or shared behavior change
+  that should be published soon.
+- **No release needed**: no qualifying SDK changes since the last tag.
+- **Investigate**: commits are ambiguous and need maintainer judgment.
+
+## Step 5: Verify before release or merge
+
+Run the smallest relevant validation for the SDKs being released:
+
+```bash
+# Python
+cd flipt-python && make test
+
+# Node.js
+cd flipt-node && npm test && npm run build
+
+# Java
+cd flipt-java && ./gradlew test
+
+# Rust
+cd flipt-rust && cargo test
+
+# PHP
+cd flipt-php && composer test
+
+# C#
+cd flipt-csharp && dotnet test
+```
+
+For behavior expected to be consistent across SDKs, run Dagger integration tests:
+
+```bash
+dagger run go run ./test --sdks=python,node,rust
+# or all SDKs
+dagger run go run ./test
+```
+
+## Step 6: Release flow
+
+1. Merge qualifying conventional commits to `main`.
+2. Let `.github/workflows/release-please.yml` open or update Release Please PRs.
+3. Review each release PR for the expected version bump and changelog entries.
+4. Merge the Release Please PR.
+5. Confirm the package workflow for the SDK ran successfully:
+   - `package-python-sdk.yml`
+   - `package-node-sdk.yml`
+   - `package-java-sdk.yml`
+   - `package-rust-sdk.yml`
+   - `package-php-sdk.yml`
+   - `package-csharp-sdk.yml`
+
+Do not manually create release tags unless maintainers explicitly decide to bypass
+Release Please.

--- a/.github/workflows/issue-health.yml
+++ b/.github/workflows/issue-health.yml
@@ -1,0 +1,36 @@
+name: Issue Health Check
+
+# AI health check for newly opened issues.
+#
+# The central issue-health action fetches the issue, asks the model for structured
+# actionability data, renders a comment, and applies only labels that already
+# exist in this repository. It does not create labels, close issues, assign
+# maintainers, or edit issue bodies.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-health-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  issue-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: flipt-io/agents/actions/issue-health@main # pin to a tag/SHA to freeze the checker
+        env:
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          local-config-dir: .agents/issue-health
+          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,46 @@
+name: PR Review
+
+# AI code review for PRs targeting main, including PRs from forks.
+#
+# Uses `pull_request_target` (not `pull_request`) on purpose: a `pull_request`
+# event from a fork gets a read-only token with no repo secrets, so the
+# reviewer couldn't reach Cloudflare Workers AI or post a review. With
+# `pull_request_target` the job runs in the base-repo context with a writable
+# token and access to CLOUDFLARE_* secrets.
+#
+# SECURITY: this is safe ONLY because the reviewer never checks out or executes
+# the PR's code — it reads the diff via the `gh` API. Do NOT add
+# `ref: ${{ github.event.pull_request.head.* }}` to the checkout, and do not run
+# any build steps, scripts, or Make targets from the PR in this workflow.
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip Dependabot (it runs in a restricted context and we don't review it).
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Default ref is the base branch (main), NOT the PR head — keep it that way.
+      - uses: actions/checkout@v7
+
+      - uses: flipt-io/agents/actions/pr-review@main # pin to a tag/SHA to freeze the reviewer
+        env:
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          local-config-dir: .agents/pr-review
+          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ Cargo.lock
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
+!.agents/skills/release/
+!.agents/skills/release/SKILL.md
 x64/
 x86/
 bld/


### PR DESCRIPTION
## Summary
- Add issue-health and PR-review workflows using `flipt-io/agents` with repo-local config.
- Add server SDK issue-health prompt, PR review routing, and a general server SDK reviewer persona.
- Add a repo-specific release skill for Release Please based SDK releases and a `.gitignore` exception so it is tracked.

## Test Plan
- Verified 13/13 pre-PR artifact checks passed.
- Parsed both new workflow YAML files with Ruby `YAML.load_file`.
- Ran `git diff --check`.
- Fresh-eyes reviewer checked the plan and reported no blockers after the routing path fix.
